### PR TITLE
The ServiceMonitors have wrong port name #85

### DIFF
--- a/charts/vaas/values.yaml
+++ b/charts/vaas/values.yaml
@@ -121,7 +121,7 @@ gateway:
 
   metrics:
     enabled: false
-    port: 8080
+    port: http
     path: /metrics
 
   autoscaling:
@@ -224,7 +224,7 @@ gdscan:
   metrics:
     servicemonitor:
       enabled: false
-      port: 8080
+      port: http
       path: /metrics
 
   ingress:


### PR DESCRIPTION
Switch default metrics port from "8080" to "http"