### PR TITLE
NetworkPolicies are not allow to scrape Prometheus metrics #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ In addition, Sentry will always behave as follows:
 | gateway.nameOverride                      | Overrides the application name                                                                        | ""                             |
 | gateway.fullnameOverride                  | Overrides the full name                                                                               | ""                             |
 | gateway.networkPolicy.enabled             | Enable/Disable the default Network Policy                                                             | false                          |
+| gateway.networkPolicy.ingressNSMatchLabels    | Labels to match to allow traffic from other namespaces                                                | {}                             |
+| gateway.networkPolicy.ingressNSPodMatchLabels | Pod labels to match to allow traffic from other namespaces                                            | {}                             |
 | gateway.service.type                      | Type of Kubernetes service                                                                            | ""                             |
 | gateway.service.http.port                 | HTTP port for the service                                                                             | 8080                           |
 | gateway.service.ws.port                   | WebSocket port for the service                                                                        | 9090                           |
@@ -231,6 +233,9 @@ In addition, Sentry will always behave as follows:
 | gateway.nodeSelector                      | Node labels for pod assignment                                                                        | {}                             |
 | gateway.affinity                          | Affinity settings for pods                                                                            | {}                             |
 | gateway.terminationGracePeriodSeconds     | Max time in seconds for scans to complete                                                             | 30                             |
+| gdscan.networkPolicy.enabled                  | Enable/Disable the default Network Policy                                                             | false                          |
+| gdscan.networkPolicy.ingressNSMatchLabels     | Labels to match to allow traffic from other namespaces                                                | {}                             |
+| gdscan.networkPolicy.ingressNSPodMatchLabels  | Pod labels to match to allow traffic from other namespaces                                            | {}                             |
 | gdscan.nodeSelector                       | gdscan node labels for pod assignment                                                                 | {}                             |
 | gdscan.replicaCount                       | Number of replicas for the gdscan deployment                                                          | 1                              |
 | gdscan.terminationGracePeriodSeconds      | Max time in seconds for scans to complete. Set to same value as gateway.terminationGracePeriodSeconds | 30                             |

--- a/charts/vaas/templates/gateway/networkpolicy.yaml
+++ b/charts/vaas/templates/gateway/networkpolicy.yaml
@@ -48,4 +48,25 @@ spec:
       ports:
         - port: 53
           protocol: UDP     
+    {{- if or .Values.gateway.networkPolicy.ingressNSMatchLabels .Values.gateway.networkPolicy.ingressNSPodMatchLabels }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- if .Values.gateway.networkPolicy.ingressNSMatchLabels }}
+                {{- range $key, $value := .Values.gateway.networkPolicy.ingressNSMatchLabels }}
+                {{ $key | quote }}: {{ $value | quote }}
+                {{- end }}
+              {{ else }}
+                {}
+              {{- end }}
+          {{- if .Values.gateway.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.gateway.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+      ports:
+        - port: 8080 # Upload
+    {{- end }}
 {{- end }}

--- a/charts/vaas/templates/gdscan/networkpolicy.yaml
+++ b/charts/vaas/templates/gdscan/networkpolicy.yaml
@@ -16,6 +16,24 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: gateway
+        {{- if or .Values.gdscan.networkPolicy.ingressNSMatchLabels .Values.gdscan.networkPolicy.ingressNSPodMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- if .Values.gdscan.networkPolicy.ingressNSMatchLabels }}
+                {{- range $key, $value := .Values.gdscan.networkPolicy.ingressNSMatchLabels }}
+                {{ $key | quote }}: {{ $value | quote }}
+                {{- end }}
+              {{ else }}
+                {}
+              {{- end }}
+          {{- if .Values.gdscan.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.gdscan.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
       ports:
         - port: 8080 # Upload
 {{- end }}

--- a/charts/vaas/values.yaml
+++ b/charts/vaas/values.yaml
@@ -111,6 +111,10 @@ gateway:
 
   networkPolicy:
     enabled: true
+    # ingressNSMatchLabels:
+    #   kubernetes.io/metadata.name: prometheus
+    # ingressNSPodMatchLabels:
+    #   app.kubernetes.io/name: prometheus
 
   service:
     type: ClusterIP
@@ -214,6 +218,10 @@ gdscan:
 
   networkPolicy:
     enabled: true
+    # ingressNSMatchLabels:
+    #   kubernetes.io/metadata.name: prometheus
+    # ingressNSPodMatchLabels:
+    #   app.kubernetes.io/name: prometheus
 
   podAnnotations: {}
 


### PR DESCRIPTION
Allow configuring access to gateway and gdscan with

* gateway.networkPolicy.ingressNSMatchLabels
* gateway.networkPolicy.ingressNSPodMatchLabels
* gdscan.networkPolicy.ingressNSMatchLabels
* gdscan.networkPolicy.ingressNSPodMatchLabels