### PR TITLE
remove enabled from securityContext since there are no part of the schema

### DIFF
--- a/charts/vaas/Chart.yaml
+++ b/charts/vaas/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vaas
-version: 3.2.0
+version: 3.2.1
 description: Deployment of a Verdict-as-a-Service on-premise instance
 maintainers:
   - name: G DATA CyberDefense AG

--- a/charts/vaas/values.yaml
+++ b/charts/vaas/values.yaml
@@ -320,11 +320,9 @@ redis:
   persistence:
     enabled: false
   podSecurityContext:
-    enabled: true
     fsGroupChangePolicy: "OnRootMismatch"
     fsGroup: 1001
   containerSecurityContext:
-    enabled: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true


### PR DESCRIPTION
How securityEvents are parsed in the redis helm chart:
https://github.com/CloudPirates-io/helm-charts/blob/638551230ace7b7e194afdcfb659108a5a23865b/charts/redis/templates/statefulset.yaml#L35
https://github.com/CloudPirates-io/helm-charts/blob/638551230ace7b7e194afdcfb659108a5a23865b/charts/redis/templates/statefulset.yaml#L148